### PR TITLE
fix filtered words by removing alert

### DIFF
--- a/contexts/DataContext.tsx
+++ b/contexts/DataContext.tsx
@@ -100,8 +100,6 @@ export const DataContextProvider = ({
 
   const filteredWords = useMemo(() => {
     if (!language) return words;
-    showAlert("error", "Invalid language selected");
-
     return words.filter((w) => w.languageId === language.id);
   }, [words, language]);
 


### PR DESCRIPTION
## Summary
- remove alert from filteredWords memo and filter only when language exists

## Testing
- `npm test`
- `npm run lint` *(fails: 82 problems (3 errors, 79 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68ad9a99333c832ebaa15ff3a4987360