### PR TITLE
Use strict equality for image archive category filter

### DIFF
--- a/app/(tabs)/(images)/archive.tsx
+++ b/app/(tabs)/(images)/archive.tsx
@@ -27,7 +27,7 @@ const Archive = () => {
 
   const selectedWords = useMemo(() => {
     if (!selectedCategory) return [];
-    return filteredWords.filter((w) => w.categoryId == selectedCategory.id);
+    return filteredWords.filter((w) => w.categoryId === selectedCategory.id);
   }, [selectedCategory, filteredWords]);
 
   const searchedWords = useMemo(() => {


### PR DESCRIPTION
## Summary
- use strict equality when filtering archived image words by category id

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `CI=true npm run lint` *(fails: 81 problems: 3 errors, 78 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68ad9e12781c832ea9b74d82b3fe4e0b