### PR TITLE
Add dependency array for BillingContext listener

### DIFF
--- a/contexts/BillingContext.tsx
+++ b/contexts/BillingContext.tsx
@@ -62,7 +62,7 @@ export const BillingContextProvider = ({ children }: any) => {
     return () => {
       Purchases.removeCustomerInfoUpdateListener(getUserDetails);
     };
-  });
+  }, []);
 
   useEffect(() => {
     Purchases.setLogLevel(LOG_LEVEL.VERBOSE);


### PR DESCRIPTION
## Summary
- ensure Purchases customer info listener in BillingContext runs once on mount by adding an empty dependency array

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm run lint` *(fails: Definition for rule 'react-native/no-inline-styles' was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ada7cdcc74832e93e3bbdde9ff733a