### PR TITLE
refactor: use Text for error in images layout

### DIFF
--- a/app/(tabs)/(images)/_layout.tsx
+++ b/app/(tabs)/(images)/_layout.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef } from "react";
 import { Slot } from "expo-router";
 import { ScrollView } from "@/components/ui/scroll-view";
 import { View } from "@/components/ui/view";
+import { Text } from "@/components/ui/text";
 import {
   useSharedValue,
   interpolate,
@@ -48,7 +49,7 @@ const ImagesLayout = () => {
 
   if (loading) return <PageLoader />;
 
-  if (error) return <p>{error.message}</p>;
+  if (error) return <Text>{error.message}</Text>;
 
   return (
     <View className="flex-1">


### PR DESCRIPTION
## Summary
- use `Text` component to render error message in images layout

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm run lint` *(fails: Component definition is missing display name)*

------
https://chatgpt.com/codex/tasks/task_e_68ada7e817d4832eb60c164402aa2b7f