### PR TITLE
refactor: type card icons with React.ElementType

### DIFF
--- a/components/screens/settings/ExpandableCard.tsx
+++ b/components/screens/settings/ExpandableCard.tsx
@@ -14,7 +14,7 @@ import { HStack } from "@/components/ui/hstack";
 
 interface ExpandableCardProps {
   title: string;
-  icon: any;
+  icon: React.ElementType;
   children: ReactNode;
 }
 

--- a/components/screens/settings/RedirectCard.tsx
+++ b/components/screens/settings/RedirectCard.tsx
@@ -4,7 +4,7 @@ import { Text } from "@/components/ui/text";
 import { ChevronRightIcon, Icon } from "@/components/ui/icon";
 import { Box } from "@/components/ui/box";
 
-const RedirectCard = ({ title, icon }: { title: string; icon: any }) => {
+const RedirectCard = ({ title, icon }: { title: string; icon: React.ElementType }) => {
   return (
     <Pressable className="p-3 h-14 items-center bg-background-100 rounded-[18px] gap-3 flex flex-row data-[active=true]:bg-primary-100">
       <Box className="p-3">

--- a/components/screens/settings/SelectCard.tsx
+++ b/components/screens/settings/SelectCard.tsx
@@ -17,7 +17,7 @@ import { Language } from "@/types";
 
 interface SelectCardProps {
   placeholder: string;
-  icon: any;
+  icon: React.ElementType;
   options: Language[];
   onValueChange?: (value: string) => void;
   value?: string;

--- a/components/screens/settings/ThemeCard.tsx
+++ b/components/screens/settings/ThemeCard.tsx
@@ -5,7 +5,7 @@ import { Icon } from "@/components/ui/icon";
 
 interface IThemeCard {
   title: string;
-  icon: any;
+  icon: React.ElementType;
   onPress: () => void;
   active: boolean;
 }


### PR DESCRIPTION
## Summary
- use React.ElementType for icon prop across settings cards

## Testing
- `npx tsc --noEmit components/screens/settings/ThemeCard.tsx components/screens/settings/ExpandableCard.tsx components/screens/settings/SelectCard.tsx components/screens/settings/RedirectCard.tsx` *(fails: Duplicate identifier 'AbortController')*
- `npm run lint` *(fails: 3 errors, 72 warnings)*
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adac7886cc832ea3897ab47b21615c