### PR TITLE
refactor: memoize showAlert handler

### DIFF
--- a/contexts/DataContext.tsx
+++ b/contexts/DataContext.tsx
@@ -78,19 +78,20 @@ export const DataContextProvider = ({
   const [language, setLanguage] = useState<Language | undefined>(undefined);
   const toast = useToast();
 
-  const showAlert = (severity: any, title: string) => {
-    toast.show({
-      placement: "bottom right",
-      duration: 3000,
-      render: ({ id }) => {
-        return (
+  const showAlert = useCallback(
+    (severity: "success" | "error" | "info", title: string) => {
+      toast.show({
+        placement: "bottom right",
+        duration: 3000,
+        render: () => (
           <Toast action={severity} variant="solid">
             <ToastTitle>{title}</ToastTitle>
           </Toast>
-        );
-      },
-    });
-  };
+        ),
+      });
+    },
+    [toast],
+  );
 
   useEffect(() => {
     if (!language && supportedLanguages.length > 0) {
@@ -128,7 +129,7 @@ export const DataContextProvider = ({
       showAlert("info", `Language changed to ${found.name}`);
       setLanguage(found);
     },
-    [supportedLanguages, showAlert],
+    [showAlert, supportedLanguages],
   );
 
   const processItem = useCallback(
@@ -139,7 +140,7 @@ export const DataContextProvider = ({
       }
       await mutation.mutateAsync({ image, language: language.iso639 });
     },
-    [language, mutation, showAlert],
+    [showAlert, language, mutation],
   );
 
   const value = useMemo<DataContextProps>(


### PR DESCRIPTION
## Summary
- memoize DataContext alerts with `useCallback`
- narrow `showAlert` severity to specific strings
- update changeLanguage and processItem dependencies

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm run lint` *(fails: Definition for rule 'react-native/no-inline-styles' was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adac86aafc832e932fc0a309086e0f