### PR TITLE
chore: type scroll events

### DIFF
--- a/app/(tabs)/(images)/_layout.tsx
+++ b/app/(tabs)/(images)/_layout.tsx
@@ -3,6 +3,7 @@ import { Slot } from "expo-router";
 import { ScrollView } from "@/components/ui/scroll-view";
 import { View } from "@/components/ui/view";
 import { Text } from "@/components/ui/text";
+import { NativeScrollEvent, NativeSyntheticEvent } from "react-native";
 import {
   useSharedValue,
   interpolate,
@@ -33,7 +34,9 @@ const ImagesLayout = () => {
     }
   }, [scrollViewRef]);
 
-  const handleScrollWithPosition = (event: any) => {
+  const handleScrollWithPosition = (
+    event: NativeSyntheticEvent<NativeScrollEvent>,
+  ) => {
     const y = event.nativeEvent.contentOffset.y;
     scrollY.value = y;
 

--- a/components/ui/grid/index.tsx
+++ b/components/ui/grid/index.tsx
@@ -7,7 +7,14 @@ import React, {
   forwardRef,
 } from "react";
 import type { VariantProps } from "@gluestack-ui/nativewind-utils";
-import { View, Dimensions, Platform, ViewProps } from "react-native";
+import {
+  View,
+  Dimensions,
+  Platform,
+  ViewProps,
+  NativeScrollEvent,
+  NativeSyntheticEvent,
+} from "react-native";
 import { gridStyle, gridItemStyle } from "./styles";
 import { cssInterop } from "nativewind";
 import {
@@ -197,7 +204,7 @@ const Grid = forwardRef<React.ElementRef<typeof View>, IGridProps>(
           className={gridStyle({
             class: className + " " + gridClassMerged,
           })}
-          onLayout={(event: any) => {
+          onLayout={(event: NativeSyntheticEvent<NativeScrollEvent>) => {
             const paddingLeftToSubtract =
               props?.paddingStart || props?.paddingLeft || props?.padding || 0;
 
@@ -205,7 +212,7 @@ const Grid = forwardRef<React.ElementRef<typeof View>, IGridProps>(
               props?.paddingEnd || props?.paddingRight || props?.padding || 0;
 
             const gridWidth =
-              event.nativeEvent.layout.width -
+              event.nativeEvent.layoutMeasurement.width -
               paddingLeftToSubtract -
               paddingRightToSubtract -
               borderWidthToSubtract;


### PR DESCRIPTION
## Summary
- type Images layout scroll handler with `NativeSyntheticEvent<NativeScrollEvent>`
- apply same typing to grid layout handler

## Testing
- `npm run lint` *(fails: Definition for rule 'react-native/no-inline-styles' was not found)*
- `npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68adac845c08832eaf6bf9b8d8a8e82b