### PR TITLE
chore: remove unused imports from GameCard component

### DIFF
--- a/components/screens/games/GameCard.tsx
+++ b/components/screens/games/GameCard.tsx
@@ -1,9 +1,8 @@
-import { Box } from "@/components/ui/box";
 import { Card } from "@/components/ui/card";
 import { Image } from "@/components/ui/image";
 import { Text } from "@/components/ui/text";
 import { FlashCard } from "@/types";
-import { View, StyleSheet } from "react-native";
+import { View } from "react-native";
 import Animated from "react-native-reanimated";
 
 const GameCard = ({ currentCard }: { currentCard: FlashCard }) => {


### PR DESCRIPTION
## Summary
- remove unused Box and StyleSheet imports from GameCard component

## Testing
- `npm run lint` (fails: 71 problems, 3 errors)
- `npx eslint components/screens/games/GameCard.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ade1e5afe0832e8dafee2be1268258