### PR TITLE
Use union type for flashcard toast severity

### DIFF
--- a/app/(tabs)/flashcards.tsx
+++ b/app/(tabs)/flashcards.tsx
@@ -31,7 +31,10 @@ const Flashcards = () => {
   const x = useSharedValue(0);
   const toast = useToast();
 
-  const showAlert = (severity: any, title: string) => {
+  const showAlert = (
+    severity: "success" | "error" | "info",
+    title: string,
+  ) => {
     toast.show({
       placement: "bottom right",
       duration: 500,


### PR DESCRIPTION
## Summary
- restrict flashcard toast severity to explicit union type

## Testing
- `npm run lint` *(fails: Definition for rule 'react-native/no-inline-styles' was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ade22c7fac832e89df1beefdb46640