### PR TITLE
feat: improve accessibility for image cards

### DIFF
--- a/components/screens/images/CategoryCard.tsx
+++ b/components/screens/images/CategoryCard.tsx
@@ -14,6 +14,9 @@ interface ICategoryCard {
 const CategoryCard = ({ id, emoji, text }: ICategoryCard) => {
   return (
     <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={`Open ${text} category`}
+      accessibilityHint={`Opens the ${text} category`}
       onPress={() =>
         router.push({
           pathname: "/(tabs)/(images)/archive",

--- a/components/screens/images/WordCard.tsx
+++ b/components/screens/images/WordCard.tsx
@@ -29,6 +29,9 @@ const WordCard = ({ word }: IWordCard) => {
       />
 
       <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={`View details for ${word.name}`}
+        accessibilityHint="Opens word details"
         onPress={() => !loading && setShowModal(true)}
         className="rounded-[18px] bg-background-100 p-4 data-[active=true]:bg-primary-100"
       >


### PR DESCRIPTION
## Summary
- add accessibility labels and role to category cards
- add accessibility labels and role to word cards

## Testing
- `npm run lint` *(fails: 70 problems (3 errors, 67 warnings))*
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68ae36e598b0832ea0f037aadc8d9c78