### PR TITLE
Add alt text to GameCard image

### DIFF
--- a/components/screens/games/GameCard.tsx
+++ b/components/screens/games/GameCard.tsx
@@ -11,6 +11,7 @@ const GameCard = ({ currentCard }: { currentCard: FlashCard }) => {
       <Animated.View>
         <Image
           className="mb-6 h-[240px] w-full rounded-md aspect-[263/240]"
+          alt={`Image of ${currentCard.word}`}
           source={
             typeof currentCard.image === "string"
               ? { uri: currentCard.image }


### PR DESCRIPTION
## Summary
- add descriptive alt text for GameCard images

## Testing
- `CI=1 npm test`
- `npm run lint` *(fails: No ESLint config found, configuring automatically)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Found 5 errors in 2 files)*

------
https://chatgpt.com/codex/tasks/task_e_68ae36e83be8832e95699e68b6158a93