### PR TITLE
Show skeleton placeholder while word image loads

### DIFF
--- a/components/screens/images/WordCard.tsx
+++ b/components/screens/images/WordCard.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { Box } from "@/components/ui/box";
 import { HStack } from "@/components/ui/hstack";
 import { Image } from "@/components/ui/image";
+import { Skeleton } from "@/components/ui/skeleton";
 import { Text } from "@/components/ui/text";
 import { VStack } from "@/components/ui/vstack";
 import { Pressable } from "@/components/ui/pressable";
@@ -33,7 +34,7 @@ const WordCard = ({ word }: IWordCard) => {
         className="rounded-[18px] bg-background-100 p-4 data-[active=true]:bg-primary-100"
       >
         <HStack className="items-center">
-          <Box className="mr-4 h-[96px] w-[96px] overflow-hidden rounded-[16px] bg-background-200">
+          <Box className="relative mr-4 h-[96px] w-[96px] overflow-hidden rounded-[16px] bg-background-200">
             <Image
               key={word.image}
               source={{ uri: word.image }}
@@ -43,6 +44,9 @@ const WordCard = ({ word }: IWordCard) => {
               onLoadEnd={() => setLoading(false)}
               onError={() => setLoading(false)}
             />
+            {loading && (
+              <Skeleton className="absolute left-0 top-0 h-full w-full" />
+            )}
           </Box>
 
           <VStack className="flex-1" space="xs">


### PR DESCRIPTION
## Summary
- add Skeleton placeholder to WordCard images
- remove placeholder once image load finishes or errors

## Testing
- `npm test -- --watchAll=false` (fails: No tests found)
- `npm run lint` (fails: ESLint is not configured)


------
https://chatgpt.com/codex/tasks/task_e_68ae36e87ec0832ea5e2f454d82e5935