### PR TITLE
Add safe area padding to Header component

### DIFF
--- a/components/shared/Header.tsx
+++ b/components/shared/Header.tsx
@@ -3,6 +3,7 @@ import { Heading } from '@/components/ui/heading';
 import { Text } from '@/components/ui/text';
 import { Icon } from '@/components/ui/icon';
 import { Pressable } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 interface HeaderButtonProps {
   text: string;
@@ -17,8 +18,9 @@ interface HeaderProps {
 }
 
 export const Header = ({ title, leftButton, rightButton }: HeaderProps) => {
+  const { top } = useSafeAreaInsets();
   return (
-    <HStack className="h-14 items-center px-4 mb-2 sticky top-0 z-10">
+    <HStack className="h-14 items-center px-4 mb-2 sticky top-0 z-10" style={{ paddingTop: top }}>
       {leftButton && (
         <Pressable
           onPress={leftButton.onClick}


### PR DESCRIPTION
## Summary
- use `useSafeAreaInsets` to pad the top of `Header`

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae4f59fddc832e8586c77745a56794