### PR TITLE
refactor: add async openLinkInBrowser

### DIFF
--- a/app/utils/openLinkInBrowser.ts
+++ b/app/utils/openLinkInBrowser.ts
@@ -3,6 +3,16 @@ import { Linking } from "react-native"
 /**
  * Helper for opening a give URL in an external browser.
  */
-export function openLinkInBrowser(url: string) {
-  Linking.canOpenURL(url).then((canOpen) => canOpen && Linking.openURL(url))
+export async function openLinkInBrowser(url: string): Promise<boolean> {
+  try {
+    const canOpen = await Linking.canOpenURL(url)
+    if (canOpen) {
+      await Linking.openURL(url)
+      return true
+    }
+    return false
+  } catch (e) {
+    console.error(e)
+    return false
+  }
 }


### PR DESCRIPTION
## Summary
- refactor openLinkInBrowser to use async/await and signal success with boolean return

## Testing
- `npm run lint:check` *(fails: Inline style: app/app/screens/Home/SearchBar.tsx)*
- `npm test` *(fails: missing i18n key and test timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b1caa668832e83500b35ba36d778