### PR TITLE
feat: use fisher-yates shuffle

### DIFF
--- a/app/i18n/en.ts
+++ b/app/i18n/en.ts
@@ -65,6 +65,7 @@ const en = {
   },
   learnScreen: {
     title: "Learn",
+    subtitle: "Word details",
     flashcards: "Flashcards",
     hangman: "Hangman",
   },
@@ -78,6 +79,10 @@ const en = {
     subscription: "Subscription status",
     legal: "ToS and Privacy Policy",
     code: "View code",
+    accessibility: {
+      publishLabel: "Published on {{date}}",
+      durationLabel: "Duration {{hours}}h {{minutes}}m {{seconds}}s",
+    },
   },
 }
 

--- a/app/utils/helpers.ts
+++ b/app/utils/helpers.ts
@@ -1,5 +1,10 @@
 export function shuffle<T>(arr: T[]): T[] {
-  return [...arr].sort(() => Math.random() - 0.5)
+  const a = [...arr]
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[a[i], a[j]] = [a[j], a[i]]
+  }
+  return a
 }
 
 export function sample<T>(arr: T[]): T | null {

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -1,0 +1,28 @@
+import { shuffle, sample } from "../app/utils/helpers"
+
+describe("helpers", () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  test("shuffle deterministically shuffles array", () => {
+    const randomSpy = jest
+      .spyOn(Math, "random")
+      .mockReturnValueOnce(0.1)
+      .mockReturnValueOnce(0.2)
+      .mockReturnValueOnce(0.3)
+
+    const arr = [1, 2, 3, 4]
+    const result = shuffle(arr)
+
+    expect(result).toEqual([2, 3, 4, 1])
+    expect(arr).toEqual([1, 2, 3, 4])
+    expect(randomSpy).toHaveBeenCalledTimes(3)
+  })
+
+  test("sample deterministically selects element", () => {
+    jest.spyOn(Math, "random").mockReturnValue(0.75)
+    const arr = ["a", "b", "c", "d"]
+    expect(sample(arr)).toBe("d")
+  })
+})


### PR DESCRIPTION
## Summary
- replace sort-based shuffle with Fisher–Yates algorithm
- add deterministic unit tests for shuffle and sample
- add missing i18n keys for learn and settings screens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5b1c882d8832e8242cfa552443c6a